### PR TITLE
Add Debian 13.x (trixie) and mark debian/unstable as forky, release 3.5.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -406,7 +406,7 @@ dependencies = [
 
 [[package]]
 name = "sp-variant"
-version = "3.5.4"
+version = "3.5.5"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "sp-variant"
-version = "3.5.4"
+version = "3.5.5"
 edition = "2021"
 rust-version = "1.64"
 authors = ["StorPool <support@storpool.com>"]

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -12,6 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.5.5] 2025-08-15
+
+### Additions
+
+- all:
+    - add Debian 12.x (bookworm), mark Debian unstable as Debian 13.x (trixie)
+
 ## [3.5.4] - 2025-03-25
 
 ### Other changes
@@ -641,7 +648,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - First public release.
 
-[Unreleased]: https://github.com/storpool/sp-variant/compare/release/3.5.4...main
+[Unreleased]: https://github.com/storpool/sp-variant/compare/release/3.5.5...main
+[3.5.5]: https://github.com/storpool/sp-variant/compare/release/3.5.4...release/3.5.5
 [3.5.4]: https://github.com/storpool/sp-variant/compare/release/3.5.3...release/3.5.4
 [3.5.3]: https://github.com/storpool/sp-variant/compare/release/3.5.2...release/3.5.3
 [3.5.2]: https://github.com/storpool/sp-variant/compare/release/3.5.1...release/3.5.2

--- a/python/sp_variant/defs.py
+++ b/python/sp_variant/defs.py
@@ -221,7 +221,7 @@ class RepoType(NamedTuple):
     """The base URL of the StorPool package repository."""
 
 
-VERSION: Final = "3.5.4"
+VERSION: Final = "3.5.5"
 FORMAT_VERSION: Final = (1, 4)
 
 REPO_TYPES: Final = [

--- a/python/sp_variant/vbuild.py
+++ b/python/sp_variant/vbuild.py
@@ -21,8 +21,8 @@ CMD_NOOP: Final[list[str]] = ["true"]
 
 _VARIANT_DEF: Final[list[defs.Variant | defs.VariantUpdate]] = [
     defs.Variant(
-        name="DEBIAN13",
-        descr="Debian 13.x (trixie/unstable)",
+        name="DEBIAN14",
+        descr="Debian 14.x (forky/unstable)",
         parent="",
         family="debian",
         detect=defs.Detect(
@@ -31,12 +31,12 @@ _VARIANT_DEF: Final[list[defs.Variant | defs.VariantUpdate]] = [
                 r"""^
                     PRETTY_NAME= .*
                     Debian \s+ GNU/Linux \s+
-                    (?: trixie | 13 ) (?: \s | / )
+                    (?: forky | 14 ) (?: \s | / )
                 """,
                 re.X,
             ),
             os_id="debian",
-            os_version_regex=re.compile(r"^13$"),
+            os_version_regex=re.compile(r"^14$"),
         ),
         supported=defs.Supported(repo=False),
         commands=defs.Commands(
@@ -122,12 +122,39 @@ _VARIANT_DEF: Final[list[defs.Variant | defs.VariantUpdate]] = [
         file_ext="deb",
         initramfs_flavor="update-initramfs",
         builder=defs.Builder(
-            alias="debian13",
+            alias="debian14",
             base_image="debian:unstable",
             branch="debian/unstable",
             kernel_package="linux-headers",
             utf8_locale="C.UTF-8",
         ),
+    ),
+    defs.VariantUpdate(
+        name="DEBIAN13",
+        descr="Debian 13.x (trixie)",
+        parent="DEBIAN14",
+        detect=defs.Detect(
+            filename="/etc/os-release",
+            regex=re.compile(
+                r"""^
+                    PRETTY_NAME= .*
+                    Debian \s+ GNU/Linux \s+
+                    (?: trixie | 13 ) (?: \s | / )
+                """,
+                re.X,
+            ),
+            os_id="debian",
+            os_version_regex=re.compile(r"^13$"),
+        ),
+        updates={
+            "supported": {"repo": True},
+            "repo": {"codename": "trixie"},
+            "builder": {
+                "alias": "debian13",
+                "base_image": "debian:trixie",
+                "branch": "debian/trixie",
+            },
+        },
     ),
     defs.VariantUpdate(
         name="DEBIAN12",

--- a/rust/data.rs
+++ b/rust/data.rs
@@ -38,8 +38,10 @@ pub enum VariantKind {
     DEBIAN11,
     /// Debian 12.x (bookworm)
     DEBIAN12,
-    /// Debian 13.x (trixie/unstable)
+    /// Debian 13.x (trixie)
     DEBIAN13,
+    /// Debian 14.x (forky/unstable)
+    DEBIAN14,
     /// Oracle Linux 7.x
     ORACLE7,
     /// Oracle Linux 8.x
@@ -72,6 +74,7 @@ impl VariantKind {
     const DEBIAN11_NAME: &'static str = "DEBIAN11";
     const DEBIAN12_NAME: &'static str = "DEBIAN12";
     const DEBIAN13_NAME: &'static str = "DEBIAN13";
+    const DEBIAN14_NAME: &'static str = "DEBIAN14";
     const ORACLE7_NAME: &'static str = "ORACLE7";
     const ORACLE8_NAME: &'static str = "ORACLE8";
     const ORACLE9_NAME: &'static str = "ORACLE9";
@@ -97,6 +100,7 @@ impl AsRef<str> for VariantKind {
             Self::DEBIAN11 => Self::DEBIAN11_NAME,
             Self::DEBIAN12 => Self::DEBIAN12_NAME,
             Self::DEBIAN13 => Self::DEBIAN13_NAME,
+            Self::DEBIAN14 => Self::DEBIAN14_NAME,
             Self::ORACLE7 => Self::ORACLE7_NAME,
             Self::ORACLE8 => Self::ORACLE8_NAME,
             Self::ORACLE9 => Self::ORACLE9_NAME,
@@ -126,6 +130,7 @@ impl FromStr for VariantKind {
             Self::DEBIAN11_NAME => Ok(Self::DEBIAN11),
             Self::DEBIAN12_NAME => Ok(Self::DEBIAN12),
             Self::DEBIAN13_NAME => Ok(Self::DEBIAN13),
+            Self::DEBIAN14_NAME => Ok(Self::DEBIAN14),
             Self::ORACLE7_NAME => Ok(Self::ORACLE7),
             Self::ORACLE8_NAME => Ok(Self::ORACLE8),
             Self::ORACLE9_NAME => Ok(Self::ORACLE9),
@@ -159,9 +164,9 @@ pub fn get_variants() -> &'static VariantDefTop {
                     VariantKind::ROCKY8,
                     VariantKind::ROCKY9,
                     VariantKind::RHEL8,
+                    VariantKind::ORACLE9,
                     VariantKind::ORACLE8,
                     VariantKind::ORACLE7,
-                    VariantKind::ORACLE9,
                     VariantKind::CENTOS7,
                     VariantKind::CENTOS8,
                     VariantKind::CENTOS9,
@@ -175,6 +180,7 @@ pub fn get_variants() -> &'static VariantDefTop {
                     VariantKind::DEBIAN11,
                     VariantKind::DEBIAN12,
                     VariantKind::DEBIAN13,
+                    VariantKind::DEBIAN14,
             ],
             variants: HashMap::from(
                 [
@@ -1451,9 +1457,9 @@ fi
                             VariantKind::DEBIAN13,
                             Variant {
                                 kind: VariantKind::DEBIAN13,
-                                descr: "Debian 13.x (trixie/unstable)".to_owned(),
+                                descr: "Debian 13.x (trixie)".to_owned(),
                                 family: "debian".to_owned(),
-                                parent: "".to_owned(),
+                                parent: "DEBIAN14".to_owned(),
                                 detect: Detect {
                                     filename: "/etc/os-release".to_owned(),
                                     #[allow(clippy::needless_raw_strings)]
@@ -1465,6 +1471,162 @@ fi
                                     os_id: "debian".to_owned(),
                                     #[allow(clippy::needless_raw_strings)]
                                     os_version_regex: r"^13$".to_owned(),
+                                },
+                                supported: Supported {
+                                    repo: true,
+                                },
+                                commands: HashMap::from(
+                                    [
+                                        (
+                                            "package".to_owned(),
+                                            HashMap::from(
+                                                [
+                                                    (
+                                                        "install".to_owned(),
+                                                        vec![
+                                                            "env".to_owned(),
+                                                            "DEBIAN_FRONTEND=noninteractive".to_owned(),
+                                                            "apt-get".to_owned(),
+                                                            "-q".to_owned(),
+                                                            "-y".to_owned(),
+                                                            "--no-install-recommends".to_owned(),
+                                                            "install".to_owned(),
+                                                            "--".to_owned(),
+                                                        ],
+                                                    ),
+                                                    (
+                                                        "list_all".to_owned(),
+                                                        vec![
+                                                            "dpkg-query".to_owned(),
+                                                            "-W".to_owned(),
+                                                            "-f".to_owned(),
+                                                            "${Package}\\t${Version}\\t${Architecture}\\t${db:Status-Abbrev}\\n".to_owned(),
+                                                            "--".to_owned(),
+                                                        ],
+                                                    ),
+                                                    (
+                                                        "purge".to_owned(),
+                                                        vec![
+                                                            "env".to_owned(),
+                                                            "DEBIAN_FRONTEND=noninteractive".to_owned(),
+                                                            "apt-get".to_owned(),
+                                                            "-q".to_owned(),
+                                                            "-y".to_owned(),
+                                                            "purge".to_owned(),
+                                                            "--".to_owned(),
+                                                        ],
+                                                    ),
+                                                    (
+                                                        "remove".to_owned(),
+                                                        vec![
+                                                            "env".to_owned(),
+                                                            "DEBIAN_FRONTEND=noninteractive".to_owned(),
+                                                            "apt-get".to_owned(),
+                                                            "-q".to_owned(),
+                                                            "-y".to_owned(),
+                                                            "remove".to_owned(),
+                                                            "--".to_owned(),
+                                                        ],
+                                                    ),
+                                                    (
+                                                        "remove_impl".to_owned(),
+                                                        vec![
+                                                            "env".to_owned(),
+                                                            "DEBIAN_FRONTEND=noninteractive".to_owned(),
+                                                            "dpkg".to_owned(),
+                                                            "-r".to_owned(),
+                                                            "--".to_owned(),
+                                                        ],
+                                                    ),
+                                                    (
+                                                        "update_db".to_owned(),
+                                                        vec![
+                                                            "apt-get".to_owned(),
+                                                            "-q".to_owned(),
+                                                            "-y".to_owned(),
+                                                            "update".to_owned(),
+                                                        ],
+                                                    ),
+                                                ]
+                                            ),
+                                        ),
+                                        (
+                                            "pkgfile".to_owned(),
+                                            HashMap::from(
+                                                [
+                                                    (
+                                                        "dep_query".to_owned(),
+                                                        vec![
+                                                            "sh".to_owned(),
+                                                            "-c".to_owned(),
+                                                            "dpkg-deb -f -- \"$pkg\" \"Depends\" | sed -e \"s/ *, */,/g\" | tr \",\" \"\\n\"".to_owned(),
+                                                        ],
+                                                    ),
+                                                    (
+                                                        "install".to_owned(),
+                                                        vec![
+                                                            "sh".to_owned(),
+                                                            "-c".to_owned(),
+                                                            "env DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends --reinstall -y -o DPkg::Options::=--force-confnew -- $packages".to_owned(),
+                                                        ],
+                                                    ),
+                                                ]
+                                            ),
+                                        ),
+                                    ]
+                                ),
+                                min_sys_python: "3.11".to_owned(),
+                                repo:
+                                    Repo::Deb(DebRepo {
+                                        codename: "trixie".to_owned(),
+                                        vendor: "debian".to_owned(),
+                                        sources: "debian/repo/storpool.sources".to_owned(),
+                                        keyring: "debian/repo/storpool-keyring.gpg".to_owned(),
+                                        req_packages: vec![
+                                            "ca-certificates".to_owned(),
+                                        ],
+                                    }),
+                                    package: HashMap::from(
+                                    [
+                                        ("BINDINGS_PYTHON".to_owned(), "python3".to_owned()),
+                                        ("BINDINGS_PYTHON_CONFGET".to_owned(), "python3-confget".to_owned()),
+                                        ("BINDINGS_PYTHON_SIMPLEJSON".to_owned(), "python3-simplejson".to_owned()),
+                                        ("CGROUP".to_owned(), "cgroup-tools".to_owned()),
+                                        ("CPUPOWER".to_owned(), "linux-cpupower".to_owned()),
+                                        ("LIBSSL".to_owned(), "libssl3".to_owned()),
+                                        ("MCELOG".to_owned(), "bash".to_owned()),
+                                    ]
+                                ),
+                                systemd_lib: "lib/systemd/system".to_owned(),
+                                file_ext: "deb".to_owned(),
+                                initramfs_flavor: "update-initramfs".to_owned(),
+                                builder: Builder {
+                                    alias: "debian13".to_owned(),
+                                    base_image: "debian:trixie".to_owned(),
+                                    branch: "debian/trixie".to_owned(),
+                                    kernel_package: "linux-headers".to_owned(),
+                                    utf8_locale: "C.UTF-8".to_owned(),
+                                },
+                            },
+                    ),
+                    (
+                            VariantKind::DEBIAN14,
+                            Variant {
+                                kind: VariantKind::DEBIAN14,
+                                descr: "Debian 14.x (forky/unstable)".to_owned(),
+                                family: "debian".to_owned(),
+                                parent: "".to_owned(),
+                                detect: Detect {
+                                    filename: "/etc/os-release".to_owned(),
+                                    #[allow(clippy::needless_raw_strings)]
+                                    regex: r"^
+                    PRETTY_NAME= .*
+                    Debian \s+ GNU/Linux \s+
+                    (?: forky | 14 ) (?: \s | / )
+                ".to_owned(),
+                                    os_id: "debian".to_owned(),
+                                    #[allow(clippy::needless_raw_strings)]
+                                    os_version_regex: r"^14$".to_owned(),
                                 },
                                 supported: Supported {
                                     repo: false,
@@ -1595,7 +1757,7 @@ fi
                                 file_ext: "deb".to_owned(),
                                 initramfs_flavor: "update-initramfs".to_owned(),
                                 builder: Builder {
-                                    alias: "debian13".to_owned(),
+                                    alias: "debian14".to_owned(),
                                     base_image: "debian:unstable".to_owned(),
                                     branch: "debian/unstable".to_owned(),
                                     kernel_package: "linux-headers".to_owned(),
@@ -1875,10 +2037,10 @@ for f in $packages; do
 done
 
 if [ -n \"$to_install\" ]; then
-    dnf install -y --disablerepo='*' --enablerepo=ol8_appstream,ol8_codeready_builder,ol8_baseos_latest,storpool-contrib --setopt=localpkg_gpgcheck=0 -- $to_install
+    dnf install -y --disablerepo='*' --enablerepo=ol8_appstream,ol8_baseos_latest,ol8_codeready_builder,storpool-contrib --setopt=localpkg_gpgcheck=0 -- $to_install
 fi
 if [ -n \"$to_reinstall\" ]; then
-    dnf reinstall -y --disablerepo='*' --enablerepo=ol8_appstream,ol8_codeready_builder,ol8_baseos_latest,storpool-contrib --setopt=localpkg_gpgcheck=0 -- $to_reinstall
+    dnf reinstall -y --disablerepo='*' --enablerepo=ol8_appstream,ol8_baseos_latest,ol8_codeready_builder,storpool-contrib --setopt=localpkg_gpgcheck=0 -- $to_reinstall
 fi
 ".to_owned(),
                                                         ],
@@ -1922,109 +2084,109 @@ fi
                             },
                     ),
                     (
-                        VariantKind::ORACLE9,
-                        Variant {
-                            kind: VariantKind::ORACLE9,
-                            descr: "Oracle Linux 9.x".to_owned(),
-                            family: "redhat".to_owned(),
-                            parent: "".to_owned(),
-                            detect: Detect {
-                                filename: "/etc/oracle-release".to_owned(),
-                                #[allow(clippy::needless_raw_strings)]
-                                regex: r"^ Oracle \s+ Linux \s+ Server \s+ release \s .* \s 9 \. (?: [4-9] | [1-9][0-9] )".to_owned(),
-                                os_id: "ol".to_owned(),
-                                #[allow(clippy::needless_raw_strings)]
-                                os_version_regex: r"^9(?:$|\.[0-9])".to_owned(),
-                            },
-                            supported: Supported {
-                                repo: false,
-                            },
-                            commands: HashMap::from(
-                                [
-                                    (
-                                        "package".to_owned(),
-                                        HashMap::from(
-                                            [
-                                                (
-                                                    "install".to_owned(),
-                                                    vec![
-                                                        "dnf".to_owned(),
-                                                        "--disablerepo=*".to_owned(),
-                                                        "--enablerepo=ol9_appstream".to_owned(),
-                                                        "--enablerepo=ol9_baseos_latest".to_owned(),
-                                                        "--enablerepo=ol9_codeready_builder".to_owned(),
-                                                        "--enablerepo=storpool-contrib".to_owned(),
+                            VariantKind::ORACLE9,
+                            Variant {
+                                kind: VariantKind::ORACLE9,
+                                descr: "Oracle Linux 9.x".to_owned(),
+                                family: "redhat".to_owned(),
+                                parent: "".to_owned(),
+                                detect: Detect {
+                                    filename: "/etc/oracle-release".to_owned(),
+                                    #[allow(clippy::needless_raw_strings)]
+                                    regex: r"^ Oracle \s+ Linux \s+ Server \s+ release \s .* \s 9 \. (?: [4-9] | [1-9][0-9] )".to_owned(),
+                                    os_id: "ol".to_owned(),
+                                    #[allow(clippy::needless_raw_strings)]
+                                    os_version_regex: r"^9(?:$|\.[0-9])".to_owned(),
+                                },
+                                supported: Supported {
+                                    repo: false,
+                                },
+                                commands: HashMap::from(
+                                    [
+                                        (
+                                            "package".to_owned(),
+                                            HashMap::from(
+                                                [
+                                                    (
                                                         "install".to_owned(),
-                                                        "-q".to_owned(),
-                                                        "-y".to_owned(),
-                                                        "--".to_owned(),
-                                                    ],
-                                                ),
-                                                (
-                                                    "list_all".to_owned(),
-                                                    vec![
-                                                        "rpm".to_owned(),
-                                                        "-qa".to_owned(),
-                                                        "--qf".to_owned(),
-                                                        "%{Name}\\t%{EVR}\\t%{Arch}\\tii\\n".to_owned(),
-                                                        "--".to_owned(),
-                                                    ],
-                                                ),
-                                                (
-                                                    "purge".to_owned(),
-                                                    vec![
-                                                        "yum".to_owned(),
+                                                        vec![
+                                                            "dnf".to_owned(),
+                                                            "--disablerepo=*".to_owned(),
+                                                            "--enablerepo=ol9_appstream".to_owned(),
+                                                            "--enablerepo=ol9_baseos_latest".to_owned(),
+                                                            "--enablerepo=ol9_codeready_builder".to_owned(),
+                                                            "--enablerepo=storpool-contrib".to_owned(),
+                                                            "install".to_owned(),
+                                                            "-q".to_owned(),
+                                                            "-y".to_owned(),
+                                                            "--".to_owned(),
+                                                        ],
+                                                    ),
+                                                    (
+                                                        "list_all".to_owned(),
+                                                        vec![
+                                                            "rpm".to_owned(),
+                                                            "-qa".to_owned(),
+                                                            "--qf".to_owned(),
+                                                            "%{Name}\\t%{EVR}\\t%{Arch}\\tii\\n".to_owned(),
+                                                            "--".to_owned(),
+                                                        ],
+                                                    ),
+                                                    (
+                                                        "purge".to_owned(),
+                                                        vec![
+                                                            "yum".to_owned(),
+                                                            "remove".to_owned(),
+                                                            "-q".to_owned(),
+                                                            "-y".to_owned(),
+                                                            "--".to_owned(),
+                                                        ],
+                                                    ),
+                                                    (
                                                         "remove".to_owned(),
-                                                        "-q".to_owned(),
-                                                        "-y".to_owned(),
-                                                        "--".to_owned(),
-                                                    ],
-                                                ),
-                                                (
-                                                    "remove".to_owned(),
-                                                    vec![
-                                                        "yum".to_owned(),
-                                                        "remove".to_owned(),
-                                                        "-q".to_owned(),
-                                                        "-y".to_owned(),
-                                                        "--".to_owned(),
-                                                    ],
-                                                ),
-                                                (
-                                                    "remove_impl".to_owned(),
-                                                    vec![
-                                                        "rpm".to_owned(),
-                                                        "-e".to_owned(),
-                                                        "--".to_owned(),
-                                                    ],
-                                                ),
-                                                (
-                                                    "update_db".to_owned(),
-                                                    vec![
-                                                        "true".to_owned(),
-                                                    ],
-                                                ),
-                                            ]
+                                                        vec![
+                                                            "yum".to_owned(),
+                                                            "remove".to_owned(),
+                                                            "-q".to_owned(),
+                                                            "-y".to_owned(),
+                                                            "--".to_owned(),
+                                                        ],
+                                                    ),
+                                                    (
+                                                        "remove_impl".to_owned(),
+                                                        vec![
+                                                            "rpm".to_owned(),
+                                                            "-e".to_owned(),
+                                                            "--".to_owned(),
+                                                        ],
+                                                    ),
+                                                    (
+                                                        "update_db".to_owned(),
+                                                        vec![
+                                                            "true".to_owned(),
+                                                        ],
+                                                    ),
+                                                ]
+                                            ),
                                         ),
-                                    ),
-                                    (
-                                        "pkgfile".to_owned(),
-                                        HashMap::from(
-                                            [
-                                                (
-                                                    "dep_query".to_owned(),
-                                                    vec![
-                                                        "sh".to_owned(),
-                                                        "-c".to_owned(),
-                                                        "rpm -qpR -- \"$pkg\"".to_owned(),
-                                                    ],
-                                                ),
-                                                (
-                                                    "install".to_owned(),
-                                                    vec![
-                                                        "sh".to_owned(),
-                                                        "-c".to_owned(),
-                                                        "
+                                        (
+                                            "pkgfile".to_owned(),
+                                            HashMap::from(
+                                                [
+                                                    (
+                                                        "dep_query".to_owned(),
+                                                        vec![
+                                                            "sh".to_owned(),
+                                                            "-c".to_owned(),
+                                                            "rpm -qpR -- \"$pkg\"".to_owned(),
+                                                        ],
+                                                    ),
+                                                    (
+                                                        "install".to_owned(),
+                                                        vec![
+                                                            "sh".to_owned(),
+                                                            "-c".to_owned(),
+                                                            "
 unset to_install to_reinstall
 for f in $packages; do
     package=\"$(rpm -qp \"$f\")\"
@@ -2036,51 +2198,51 @@ for f in $packages; do
 done
 
 if [ -n \"$to_install\" ]; then
-    dnf install -y --disablerepo='*' --enablerepo=ol9_appstream,ol9_codeready_builder,ol9_baseos_latest,storpool-contrib --setopt=localpkg_gpgcheck=0 -- $to_install
+    dnf install -y --disablerepo='*' --enablerepo=ol9_appstream,ol9_baseos_latest,ol9_codeready_builder,storpool-contrib --setopt=localpkg_gpgcheck=0 -- $to_install
 fi
 if [ -n \"$to_reinstall\" ]; then
-    dnf reinstall -y --disablerepo='*' --enablerepo=ol9_appstream,ol9_codeready_builder,ol9_baseos_latest,storpool-contrib --setopt=localpkg_gpgcheck=0 -- $to_reinstall
+    dnf reinstall -y --disablerepo='*' --enablerepo=ol9_appstream,ol9_baseos_latest,ol9_codeready_builder,storpool-contrib --setopt=localpkg_gpgcheck=0 -- $to_reinstall
 fi
 ".to_owned(),
-                                                    ],
-                                                ),
-                                            ]
+                                                        ],
+                                                    ),
+                                                ]
+                                            ),
                                         ),
-                                    ),
-                                ]
-                            ),
-                            min_sys_python: "3.9".to_owned(),
-                            repo:
-                            Repo::Yum(YumRepo {
-                                yumdef: "redhat/repo/storpool-centos.repo".to_owned(),
-                                keyring: "redhat/repo/RPM-GPG-KEY-StorPool".to_owned(),
-                            }),
-                            package: HashMap::from(
-                                [
-                                    ("KMOD".to_owned(), "kmod".to_owned()),
-                                    ("LIBCGROUP".to_owned(), "bash".to_owned()),
-                                    ("LIBUDEV".to_owned(), "systemd-libs".to_owned()),
-                                    ("OPENSSL".to_owned(), "openssl-libs".to_owned()),
-                                    ("PERL_AUTODIE".to_owned(), "perl-autodie".to_owned()),
-                                    ("PERL_FILE_PATH".to_owned(), "perl-File-Path".to_owned()),
-                                    ("PERL_LWP_PROTO_HTTPS".to_owned(), "perl-LWP-Protocol-https".to_owned()),
-                                    ("PERL_SYS_SYSLOG".to_owned(), "perl-Sys-Syslog".to_owned()),
-                                    ("PROCPS".to_owned(), "procps-ng".to_owned()),
-                                    ("PYTHON_SIMPLEJSON".to_owned(), "bash".to_owned()),
-                                    ("UDEV".to_owned(), "systemd".to_owned()),
-                                ]
-                            ),
-                            systemd_lib: "usr/lib/systemd/system".to_owned(),
-                            file_ext: "rpm".to_owned(),
-                            initramfs_flavor: "mkinitrd".to_owned(),
-                            builder: Builder {
-                                alias: "oracle9".to_owned(),
-                                base_image: "oraclelinux:9".to_owned(),
-                                branch: "".to_owned(),
-                                kernel_package: "kernel-core".to_owned(),
-                                utf8_locale: "C.UTF-8".to_owned(),
+                                    ]
+                                ),
+                                min_sys_python: "3.9".to_owned(),
+                                repo:
+                                    Repo::Yum(YumRepo {
+                                        yumdef: "redhat/repo/storpool-centos.repo".to_owned(),
+                                        keyring: "redhat/repo/RPM-GPG-KEY-StorPool".to_owned(),
+                                    }),
+                                    package: HashMap::from(
+                                    [
+                                        ("KMOD".to_owned(), "kmod".to_owned()),
+                                        ("LIBCGROUP".to_owned(), "bash".to_owned()),
+                                        ("LIBUDEV".to_owned(), "systemd-libs".to_owned()),
+                                        ("OPENSSL".to_owned(), "openssl-libs".to_owned()),
+                                        ("PERL_AUTODIE".to_owned(), "perl-autodie".to_owned()),
+                                        ("PERL_FILE_PATH".to_owned(), "perl-File-Path".to_owned()),
+                                        ("PERL_LWP_PROTO_HTTPS".to_owned(), "perl-LWP-Protocol-https".to_owned()),
+                                        ("PERL_SYS_SYSLOG".to_owned(), "perl-Sys-Syslog".to_owned()),
+                                        ("PROCPS".to_owned(), "procps-ng".to_owned()),
+                                        ("PYTHON_SIMPLEJSON".to_owned(), "bash".to_owned()),
+                                        ("UDEV".to_owned(), "systemd".to_owned()),
+                                    ]
+                                ),
+                                systemd_lib: "usr/lib/systemd/system".to_owned(),
+                                file_ext: "rpm".to_owned(),
+                                initramfs_flavor: "mkinitrd".to_owned(),
+                                builder: Builder {
+                                    alias: "oracle9".to_owned(),
+                                    base_image: "oraclelinux:9".to_owned(),
+                                    branch: "".to_owned(),
+                                    kernel_package: "kernel-core".to_owned(),
+                                    utf8_locale: "C.UTF-8".to_owned(),
+                                },
                             },
-                        },
                     ),
                     (
                             VariantKind::RHEL8,
@@ -3175,7 +3337,7 @@ fi
                     ),
                 ]
             ),
-            version: "3.5.4".to_owned(),
+            version: "3.5.5".to_owned(),
         }
     });
     assert!(

--- a/sp_variant.sh
+++ b/sp_variant.sh
@@ -78,6 +78,11 @@ detect_from_os_release()
 		return
 	fi
 	
+	if [ "$os_id" = 'debian' ] && printf -- '%s\n' "$version_id" | grep -Eqe '^14$'; then
+		printf -- '%s\n' 'DEBIAN14'
+		return
+	fi
+	
 	if [ "$os_id" = 'ol' ] && printf -- '%s\n' "$version_id" | grep -Eqe '^7($|\.[0-9])'; then
 		printf -- '%s\n' 'ORACLE7'
 		return
@@ -238,6 +243,11 @@ cmd_detect()
 	
 	if [ -r '/etc/os-release' ] && grep -Eqe '^PRETTY_NAME=.*Debian[[:space:]]+GNU/Linux[[:space:]]+(trixie|13)([[:space:]]|/)' -- '/etc/os-release'; then
 		printf -- '%s\n' 'DEBIAN13'
+		return
+	fi
+	
+	if [ -r '/etc/os-release' ] && grep -Eqe '^PRETTY_NAME=.*Debian[[:space:]]+GNU/Linux[[:space:]]+(forky|14)([[:space:]]|/)' -- '/etc/os-release'; then
+		printf -- '%s\n' 'DEBIAN14'
 		return
 	fi
 	
@@ -1121,6 +1131,120 @@ show_DEBIAN13()
   {
   "builder": {
     "alias": "debian13",
+    "base_image": "debian:trixie",
+    "branch": "debian/trixie",
+    "kernel_package": "linux-headers",
+    "utf8_locale": "C.UTF-8"
+  },
+  "commands": {
+    "package": {
+      "install": [
+        "env",
+        "DEBIAN_FRONTEND=noninteractive",
+        "apt-get",
+        "-q",
+        "-y",
+        "--no-install-recommends",
+        "install",
+        "--"
+      ],
+      "list_all": [
+        "dpkg-query",
+        "-W",
+        "-f",
+        "${Package}\\t${Version}\\t${Architecture}\\t${db:Status-Abbrev}\\n",
+        "--"
+      ],
+      "purge": [
+        "env",
+        "DEBIAN_FRONTEND=noninteractive",
+        "apt-get",
+        "-q",
+        "-y",
+        "purge",
+        "--"
+      ],
+      "remove": [
+        "env",
+        "DEBIAN_FRONTEND=noninteractive",
+        "apt-get",
+        "-q",
+        "-y",
+        "remove",
+        "--"
+      ],
+      "remove_impl": [
+        "env",
+        "DEBIAN_FRONTEND=noninteractive",
+        "dpkg",
+        "-r",
+        "--"
+      ],
+      "update_db": [
+        "apt-get",
+        "-q",
+        "-y",
+        "update"
+      ]
+    },
+    "pkgfile": {
+      "dep_query": [
+        "sh",
+        "-c",
+        "dpkg-deb -f -- \"$pkg\" \"Depends\" | sed -e \"s/ *, */,/g\" | tr \",\" \"\\n\""
+      ],
+      "install": [
+        "sh",
+        "-c",
+        "env DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends --reinstall -y -o DPkg::Options::=--force-confnew -- $packages"
+      ]
+    }
+  },
+  "descr": "Debian 13.x (trixie)",
+  "detect": {
+    "filename": "/etc/os-release",
+    "os_id": "debian",
+    "os_version_regex": "^13$",
+    "regex": "^\n                    PRETTY_NAME= .*\n                    Debian \\s+ GNU/Linux \\s+\n                    (?: trixie | 13 ) (?: \\s | / )\n                "
+  },
+  "family": "debian",
+  "file_ext": "deb",
+  "initramfs_flavor": "update-initramfs",
+  "min_sys_python": "3.11",
+  "name": "DEBIAN13",
+  "package": {
+    "BINDINGS_PYTHON": "python3",
+    "BINDINGS_PYTHON_CONFGET": "python3-confget",
+    "BINDINGS_PYTHON_SIMPLEJSON": "python3-simplejson",
+    "CGROUP": "cgroup-tools",
+    "CPUPOWER": "linux-cpupower",
+    "LIBSSL": "libssl3",
+    "MCELOG": "bash"
+  },
+  "parent": "DEBIAN14",
+  "repo": {
+    "codename": "trixie",
+    "keyring": "debian/repo/storpool-keyring.gpg",
+    "req_packages": [
+      "ca-certificates"
+    ],
+    "sources": "debian/repo/storpool.sources",
+    "vendor": "debian"
+  },
+  "supported": {
+    "repo": true
+  },
+  "systemd_lib": "lib/systemd/system"
+}
+EOVARIANT_JSON
+}
+
+show_DEBIAN14()
+{
+	cat <<'EOVARIANT_JSON'
+  {
+  "builder": {
+    "alias": "debian14",
     "base_image": "debian:unstable",
     "branch": "debian/unstable",
     "kernel_package": "linux-headers",
@@ -1190,18 +1314,18 @@ show_DEBIAN13()
       ]
     }
   },
-  "descr": "Debian 13.x (trixie/unstable)",
+  "descr": "Debian 14.x (forky/unstable)",
   "detect": {
     "filename": "/etc/os-release",
     "os_id": "debian",
-    "os_version_regex": "^13$",
-    "regex": "^\n                    PRETTY_NAME= .*\n                    Debian \\s+ GNU/Linux \\s+\n                    (?: trixie | 13 ) (?: \\s | / )\n                "
+    "os_version_regex": "^14$",
+    "regex": "^\n                    PRETTY_NAME= .*\n                    Debian \\s+ GNU/Linux \\s+\n                    (?: forky | 14 ) (?: \\s | / )\n                "
   },
   "family": "debian",
   "file_ext": "deb",
   "initramfs_flavor": "update-initramfs",
   "min_sys_python": "3.11",
-  "name": "DEBIAN13",
+  "name": "DEBIAN14",
   "package": {
     "BINDINGS_PYTHON": "python3",
     "BINDINGS_PYTHON_CONFGET": "python3-confget",
@@ -2352,7 +2476,8 @@ cmd_show_all()
     "DEBIAN10",
     "DEBIAN11",
     "DEBIAN12",
-    "DEBIAN13"
+    "DEBIAN13",
+    "DEBIAN14"
   ],
   "variants": {
 EOPROLOGUE
@@ -2384,6 +2509,9 @@ EOPROLOGUE
   echo ','
   printf -- '    "%s": ' 'DEBIAN13'
   show_DEBIAN13
+  echo ','
+  printf -- '    "%s": ' 'DEBIAN14'
+  show_DEBIAN14
   echo ','
   printf -- '    "%s": ' 'ORACLE7'
   show_ORACLE7
@@ -2418,7 +2546,7 @@ EOPROLOGUE
 
 	cat <<'EOEPILOGUE'
   },
-  "version": "3.5.4"
+  "version": "3.5.5"
 }
 EOEPILOGUE
 }
@@ -2442,7 +2570,7 @@ EOPROLOGUE
 
 	cat <<'EOEPILOGUE'
   ,
-  "version": "3.5.4"
+  "version": "3.5.5"
 }
 EOEPILOGUE
 }
@@ -3208,6 +3336,87 @@ fi
 			;;
 		
 		DEBIAN13)
+			case "$cmd_cat" in
+				
+				package)
+					case "$cmd_item" in
+						
+						install)
+							# The commands are quoted exactly as much as necessary.
+							# shellcheck disable=SC2016
+							$noop 'env' 'DEBIAN_FRONTEND=noninteractive' 'apt-get' '-q' '-y' '--no-install-recommends' 'install' '--'  "$@"
+							;;
+						
+						list_all)
+							# The commands are quoted exactly as much as necessary.
+							# shellcheck disable=SC2016
+							$noop 'dpkg-query' '-W' '-f' '${Package}\t${Version}\t${Architecture}\t${db:Status-Abbrev}\n' '--'  "$@"
+							;;
+						
+						purge)
+							# The commands are quoted exactly as much as necessary.
+							# shellcheck disable=SC2016
+							$noop 'env' 'DEBIAN_FRONTEND=noninteractive' 'apt-get' '-q' '-y' 'purge' '--'  "$@"
+							;;
+						
+						remove)
+							# The commands are quoted exactly as much as necessary.
+							# shellcheck disable=SC2016
+							$noop 'env' 'DEBIAN_FRONTEND=noninteractive' 'apt-get' '-q' '-y' 'remove' '--'  "$@"
+							;;
+						
+						remove_impl)
+							# The commands are quoted exactly as much as necessary.
+							# shellcheck disable=SC2016
+							$noop 'env' 'DEBIAN_FRONTEND=noninteractive' 'dpkg' '-r' '--'  "$@"
+							;;
+						
+						update_db)
+							# The commands are quoted exactly as much as necessary.
+							# shellcheck disable=SC2016
+							$noop 'apt-get' '-q' '-y' 'update'  "$@"
+							;;
+						
+
+						*)
+							echo "Invalid command '$cmd_item' in the '$cmd_cat' category" 1>&2
+							exit 1
+							;;
+					esac
+					;;
+				
+				pkgfile)
+					case "$cmd_item" in
+						
+						dep_query)
+							# The commands are quoted exactly as much as necessary.
+							# shellcheck disable=SC2016
+							$noop 'sh' '-c' 'dpkg-deb -f -- "$pkg" "Depends" | sed -e "s/ *, */,/g" | tr "," "\n"'  "$@"
+							;;
+						
+						install)
+							# The commands are quoted exactly as much as necessary.
+							# shellcheck disable=SC2016
+							$noop 'sh' '-c' 'env DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends --reinstall -y -o DPkg::Options::=--force-confnew -- $packages'  "$@"
+							;;
+						
+
+						*)
+							echo "Invalid command '$cmd_item' in the '$cmd_cat' category" 1>&2
+							exit 1
+							;;
+					esac
+					;;
+				
+
+				*)
+					echo "Invalid command category '$cmd_cat'" 1>&2
+					exit 1
+					;;
+			esac
+			;;
+		
+		DEBIAN14)
 			case "$cmd_cat" in
 				
 				package)
@@ -4395,6 +4604,12 @@ cmd_repo_add()
 			
 			;;
 		
+		DEBIAN14)
+			
+			repo_add_deb 'DEBIAN14' "$vdir" "$repotype" 'debian/repo/storpool.sources' 'debian/repo/storpool-keyring.gpg' 'ca-certificates'
+			
+			;;
+		
 		ORACLE7)
 			
 			repo_add_yum 'ORACLE7' "$vdir" "$repotype" 'redhat/repo/storpool-centos.repo' 'redhat/repo/RPM-GPG-KEY-StorPool'
@@ -4506,7 +4721,7 @@ cmd_command()
 
 cmd_features()
 {
-	echo 'Features: format=1.4 version=3.5.4'
+	echo 'Features: format=1.4 version=3.5.5'
 }
 
 case "$1" in
@@ -4588,6 +4803,10 @@ case "$1" in
 			
 			DEBIAN13)
 				show_variant 'DEBIAN13'
+				;;
+			
+			DEBIAN14)
+				show_variant 'DEBIAN14'
 				;;
 			
 			ORACLE7)


### PR DESCRIPTION
Add the builder branch definitions for Debian 13.x so sp-pkg can bootstrap a build environment for Debian 13 and PVE 9.